### PR TITLE
Use separate projects for Firebase and BigQuery

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/config.ts
+++ b/firestore-bigquery-export/scripts/import/src/config.ts
@@ -81,7 +81,7 @@ const questions = [
   },
   {
     message: "What is your BigQuery project ID?",
-    name: "bigQueryProject",
+    name: "bigqueryProject",
     type: "input",
     validate: (value) =>
       validateInput(
@@ -180,7 +180,7 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
     if (program.project === undefined) {
       errors.push("Project is not specified.");
     }
-    if (program.bigQueryProject === undefined) {
+    if (program.bigqueryProject === undefined) {
       errors.push("BigQuery Project is not specified.");
     }
     if (program.sourceCollectionPath === undefined) {
@@ -213,7 +213,7 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
     return {
       kind: "CONFIG",
       projectId: program.project,
-      bigQueryProjectId: program.bigQueryProject,
+      bigqueryProjectId: program.bigqueryProject,
       sourceCollectionPath: program.sourceCollectionPath,
       datasetId: program.dataset,
       tableId: program.tableNamePrefix,
@@ -227,7 +227,7 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
   }
   const {
     project,
-    bigQueryProject,
+    bigqueryProject,
     sourceCollectionPath,
     dataset,
     table,
@@ -242,7 +242,7 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
   return {
     kind: "CONFIG",
     projectId: project,
-    bigQueryProjectId: bigQueryProject,
+    bigqueryProjectId: bigqueryProject,
     sourceCollectionPath: sourceCollectionPath,
     datasetId: dataset,
     tableId: table,

--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -106,7 +106,7 @@ const run = async (): Promise<number> => {
 
   const {
     projectId,
-    bigQueryProjectId,
+    bigqueryProjectId,
     sourceCollectionPath,
     datasetId,
     tableId,
@@ -132,9 +132,6 @@ const run = async (): Promise<number> => {
       databaseURL: `https://${projectId}.firebaseio.com`,
     });
   }
-  // Set project ID, so it can be used in BigQuery initialization
-  process.env.PROJECT_ID = bigQueryProjectId;
-  process.env.GOOGLE_CLOUD_PROJECT = bigQueryProjectId;
 
   const rawChangeLogName = `${tableId}_raw_changelog`;
 
@@ -144,6 +141,7 @@ const run = async (): Promise<number> => {
   const dataSink = new FirestoreBigQueryEventHistoryTracker({
     tableId: tableId,
     datasetId: datasetId,
+    bqProjectId: bigqueryProjectId,
     datasetLocation,
     wildcardIds: queryCollectionGroup,
     useNewSnapshotQuerySyntax,

--- a/firestore-bigquery-export/scripts/import/src/types.ts
+++ b/firestore-bigquery-export/scripts/import/src/types.ts
@@ -3,7 +3,7 @@ import * as admin from "firebase-admin";
 export interface CliConfig {
   kind: "CONFIG";
   projectId: string;
-  bigQueryProjectId: string;
+  bigqueryProjectId: string;
   sourceCollectionPath: string;
   datasetId: string;
   tableId: string;


### PR DESCRIPTION
- Rename big query variable to match commander patterns 
- Use renamed variable to initialize call to `FirestoreBigQueryEventHistoryTracker`